### PR TITLE
refactor: clean schema-form to make them compatible with gio-form-json-schema component

### DIFF
--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -1,62 +1,58 @@
 {
-  "type": "object",
-  "id": "urn:jsonschema:io:gravitee:policy:resourcefiltering:configuration:ResourceFilteringPolicyConfiguration",
-  "properties": {
-    "whitelist": {
-      "title": "Whitelist",
-      "type": "array",
-      "items": {
-        "title": "Rule",
-        "type": "object",
-        "id": "urn:jsonschema:io:gravitee:policy:resourcefiltering:configuration:Resource",
-        "properties": {
-          "pattern": {
-            "type": "string",
-            "title": "Path pattern",
-            "description": "Ant-style path patterns"
-          },
-          "methods": {
-            "title": "Methods",
-            "description": "HTTP Methods",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+        "whitelist": {
+            "title": "Whitelist",
             "type": "array",
-            "items" : {
-              "type" : "string",
-              "enum" : [ "CONNECT", "DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT", "TRACE" ]
+            "items": {
+                "title": "Rule",
+                "type": "object",
+                "properties": {
+                    "pattern": {
+                        "type": "string",
+                        "title": "Path pattern",
+                        "description": "Ant-style path patterns"
+                    },
+                    "methods": {
+                        "title": "Methods",
+                        "description": "HTTP Methods",
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "enum": ["CONNECT", "DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT", "TRACE"]
+                        },
+                        "uniqueItems": true
+                    }
+                },
+                "required": ["pattern"]
             }
-          }
         },
-        "required": [
-          "pattern"
-        ]
-      }
-    },
-    "blacklist": {
-      "title": "Blacklist",
-      "type": "array",
-      "items": {
-        "title": "Rule",
-        "type": "object",
-        "id": "urn:jsonschema:io:gravitee:policy:resourcefiltering:configuration:Resource",
-        "properties": {
-          "pattern": {
-            "type": "string",
-            "title": "Path pattern",
-            "description": "Ant-style path patterns"
-          },
-          "methods": {
-            "title": "Methods",
-            "description": "HTTP Methods",
+        "blacklist": {
+            "title": "Blacklist",
             "type": "array",
-            "items" : {
-              "type" : "string",
-              "enum" : [ "CONNECT", "DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT", "TRACE" ]
+            "items": {
+                "title": "Rule",
+                "type": "object",
+                "properties": {
+                    "pattern": {
+                        "type": "string",
+                        "title": "Path pattern",
+                        "description": "Ant-style path patterns"
+                    },
+                    "methods": {
+                        "title": "Methods",
+                        "description": "HTTP Methods",
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "enum": ["CONNECT", "DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT", "TRACE"]
+                        },
+                        "uniqueItems": true
+                    }
+                },
+                "required": ["pattern"]
             }
-          }
-        },
-        "required": [
-          "pattern"
-        ]
-      }
+        }
     }
-  }
 }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-748

**Description**

Update schema-form to make them compatible with the new gio-form-json-schema component.

to validate these changes it is necessary that it works with the old and the new UI component
and also with backend rest-api check

 Old :
 Online checker : https://gravitee-io-labs.github.io/gravitee-schema-form-checker/
 
 New :
 Online checker : https://particles.gravitee.io/?path=/story/components-form-json-schema--string


**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.8.1-json-schema-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-resource-filtering/1.8.1-json-schema-SNAPSHOT/gravitee-policy-resource-filtering-1.8.1-json-schema-SNAPSHOT.zip)
  <!-- Version placeholder end -->
