### PR TITLE
Add opt-in URL path normalization configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,8 +4,7 @@ version: 2.1
 setup: true
 
 orbs:
-    gravitee: gravitee-io/gravitee@4.17.0
-
+    gravitee: gravitee-io/gravitee@5.5.0
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,22 +1,3 @@
 {
-  "extends": [
-    "config:base"
-  ],
-  "rebaseWhen": "conflicted",
-  "packageRules": [
-    {
-      "matchDatasources": ["orb"],
-      "matchUpdateTypes": ["patch", "minor"],
-      "automerge": true,
-      "automergeType": "branch",
-      "semanticCommitType": "ci"
-    },
-    {
-      "matchDepTypes": ["provided", "test", "build", "import", "parent"],
-      "matchUpdateTypes": ["patch", "minor"],
-      "automerge": true,
-      "automergeType": "branch",
-      "semanticCommitType": "chore"
-    }
-  ]
+    "extends": ["github>gravitee-io/renovate-config:plugin"]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+!.gitignore
+
+build/
+target/
 *.class
 
 # Mobile Tools for Java (J2ME)
@@ -17,3 +21,11 @@ hs_err_pid*
 # Idea files
 /.idea/
 *.iml
+
+# Eclipse
+.settings/
+.classpath
+.project
+
+# iOS
+.DS_Store

--- a/pom.xml
+++ b/pom.xml
@@ -95,14 +95,19 @@
 
         <!-- Test scope -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+    Copyright © 2015 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,
@@ -30,28 +30,24 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>21.0.1</version>
+        <version>23.5.0</version>
     </parent>
 
     <properties>
-        <gravitee-bom.version>5.0.0</gravitee-bom.version>
-        <gravitee-gateway-api.version>1.47.1</gravitee-gateway-api.version>
-        <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
-        <gravitee-common.version>1.28.0</gravitee-common.version>
+        <gravitee-apim.version>4.7.0</gravitee-apim.version>
 
-        <maven-assembly-plugin.version>2.6</maven-assembly-plugin.version>
-        <jackson.version>2.5.3</jackson.version>
         <!-- Property used by the publication job in CI-->
         <publish-folder-path>graviteeio-apim/plugins/policies</publish-folder-path>
+        <properties-maven-plugin.version>1.3.0</properties-maven-plugin.version>
     </properties>
 
     <dependencyManagement>
         <dependencies>
             <!-- Import bom to properly inherit all dependencies -->
             <dependency>
-                <groupId>io.gravitee</groupId>
-                <artifactId>gravitee-bom</artifactId>
-                <version>${gravitee-bom.version}</version>
+                <groupId>io.gravitee.apim</groupId>
+                <artifactId>gravitee-apim-bom</artifactId>
+                <version>${gravitee-apim.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -63,21 +59,18 @@
         <dependency>
             <groupId>io.gravitee.gateway</groupId>
             <artifactId>gravitee-gateway-api</artifactId>
-            <version>${gravitee-gateway-api.version}</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>io.gravitee.policy</groupId>
             <artifactId>gravitee-policy-api</artifactId>
-            <version>${gravitee-policy-api.version}</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>io.gravitee.common</groupId>
             <artifactId>gravitee-common</artifactId>
-            <version>${gravitee-common.version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -125,7 +118,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>properties-maven-plugin</artifactId>
-                <version>1.3.0</version>
+                <version>${properties-maven-plugin.version}</version>
                 <executions>
                     <execution>
                         <phase>initialize</phase>
@@ -144,7 +137,6 @@
             </plugin>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>${maven-assembly-plugin.version}</version>
                 <configuration>
                     <appendAssemblyId>false</appendAssemblyId>
                     <descriptors>
@@ -161,24 +153,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>com.hubspot.maven.plugins</groupId>
-                <artifactId>prettier-maven-plugin</artifactId>
-                <version>0.22</version>
-                <configuration>
-                    <nodeVersion>12.13.0</nodeVersion>
-                    <prettierJavaVersion>1.6.1</prettierJavaVersion>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>validate</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
-
 </project>

--- a/src/assembly/policy-assembly.xml
+++ b/src/assembly/policy-assembly.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+    Copyright © 2015 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/policy/resourcefiltering/PathNormalizer.java
+++ b/src/main/java/io/gravitee/policy/resourcefiltering/PathNormalizer.java
@@ -26,23 +26,48 @@ public final class PathNormalizer {
     private PathNormalizer() {}
 
     /**
+     * Normalize a URL path, preserving encoded slashes ({@code %2F}/{@code %2f}) as literal
+     * characters. Equivalent to {@link #normalize(String, boolean)} with {@code decodeEncodedSlash=false}.
+     */
+    public static String normalize(String path) {
+        return normalize(path, false);
+    }
+
+    /**
      * Normalize a URL path:
      * <ul>
      *   <li>URL-decode percent-encoded characters (%6e → n)</li>
      *   <li>Collapse multiple slashes (// → /)</li>
      *   <li>Remove dot segments (/./ and /../) per RFC 3986 §5.2.4</li>
      * </ul>
+     *
+     * @param path the request path to normalize
+     * @param decodeEncodedSlash when {@code true}, encoded slashes ({@code %2F}/{@code %2f}) are
+     *                           decoded to {@code /} and then collapsed and resolved like any
+     *                           other slash. When {@code false}, they are preserved as literal
+     *                           {@code %2F}/{@code %2f} in the output so that legitimate uses
+     *                           (e.g. identifiers containing a slash) are not altered.
      */
-    public static String normalize(String path) {
+    public static String normalize(String path, boolean decodeEncodedSlash) {
         if (path == null || path.isEmpty()) {
             return path;
         }
 
-        String decoded = URLDecoder.decode(path, StandardCharsets.UTF_8);
+        String toDecode = decodeEncodedSlash ? path : protectEncodedSlashes(path);
+        String decoded = URLDecoder.decode(toDecode, StandardCharsets.UTF_8);
         decoded = decoded.replaceAll("/+", "/");
         decoded = removeDotSegments(decoded);
 
         return decoded;
+    }
+
+    /**
+     * Double-encode {@code %2F}/{@code %2f} to {@code %252F}/{@code %252f} so that a subsequent
+     * {@link URLDecoder#decode} call produces the literal characters {@code %2F}/{@code %2f}
+     * instead of {@code /}.
+     */
+    private static String protectEncodedSlashes(String path) {
+        return path.replace("%2F", "%252F").replace("%2f", "%252f");
     }
 
     /**

--- a/src/main/java/io/gravitee/policy/resourcefiltering/PathNormalizer.java
+++ b/src/main/java/io/gravitee/policy/resourcefiltering/PathNormalizer.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.resourcefiltering;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Normalizes URL paths to prevent bypass via encoding tricks.
+ */
+public final class PathNormalizer {
+
+    private PathNormalizer() {}
+
+    /**
+     * Normalize a URL path:
+     * <ul>
+     *   <li>URL-decode percent-encoded characters (%6e → n)</li>
+     *   <li>Collapse multiple slashes (// → /)</li>
+     *   <li>Remove dot segments (/./ and /../) per RFC 3986 §5.2.4</li>
+     * </ul>
+     */
+    public static String normalize(String path) {
+        if (path == null || path.isEmpty()) {
+            return path;
+        }
+
+        String decoded = URLDecoder.decode(path, StandardCharsets.UTF_8);
+        decoded = decoded.replaceAll("/+", "/");
+        decoded = removeDotSegments(decoded);
+
+        return decoded;
+    }
+
+    /**
+     * Remove dot segments from a path per RFC 3986 §5.2.4.
+     */
+    private static String removeDotSegments(String path) {
+        StringBuilder output = new StringBuilder();
+        int i = 0;
+        while (i < path.length()) {
+            if (path.startsWith("../", i)) {
+                i += 3;
+            } else if (path.startsWith("./", i)) {
+                i += 2;
+            } else if (path.startsWith("/./", i)) {
+                i += 2;
+            } else if (i + 2 == path.length() && path.startsWith("/.", i)) {
+                output.append('/');
+                i += 2;
+            } else if (path.startsWith("/../", i)) {
+                i += 3;
+                removeLastSegment(output);
+            } else if (i + 3 == path.length() && path.startsWith("/..", i)) {
+                removeLastSegment(output);
+                output.append('/');
+                i += 3;
+            } else if ((i == path.length() - 1 && path.charAt(i) == '.') || (i == path.length() - 2 && path.startsWith("..", i))) {
+                break;
+            } else {
+                int segStart = i;
+                if (path.charAt(i) == '/') {
+                    i++;
+                }
+                int nextSlash = path.indexOf('/', i);
+                if (nextSlash == -1) {
+                    nextSlash = path.length();
+                }
+                output.append(path, segStart, nextSlash);
+                i = nextSlash;
+            }
+        }
+
+        return output.length() == 0 ? "/" : output.toString();
+    }
+
+    private static void removeLastSegment(StringBuilder output) {
+        int lastSlash = output.lastIndexOf("/");
+        if (lastSlash >= 0) {
+            output.setLength(lastSlash);
+        }
+    }
+}

--- a/src/main/java/io/gravitee/policy/resourcefiltering/ResourceFilteringPolicy.java
+++ b/src/main/java/io/gravitee/policy/resourcefiltering/ResourceFilteringPolicy.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -114,11 +114,9 @@ public class ResourceFilteringPolicy {
         for (Resource resource : resources) {
             if (
                 (resource.getMethods() == null || resource.getMethods().isEmpty() || resource.getMethods().contains(method)) &&
-                (
-                    resource.getPattern() == null ||
+                (resource.getPattern() == null ||
                     pathMatcher.match(resource.getPattern(), path) ||
-                    pathMatcher.match(contextPath + resource.getPattern(), path)
-                )
+                    pathMatcher.match(contextPath + resource.getPattern(), path))
             ) {
                 return true;
             }
@@ -137,12 +135,9 @@ public class ResourceFilteringPolicy {
     ) {
         if (!(resources == null || resources.isEmpty())) {
             for (Resource resource : resources) {
-                boolean pathMatch =
-                    (
-                        resource.getPattern() == null ||
-                        pathMatcher.match(resource.getPattern(), path) ||
-                        pathMatcher.match(contextPath + resource.getPattern(), path)
-                    );
+                boolean pathMatch = (resource.getPattern() == null ||
+                    pathMatcher.match(resource.getPattern(), path) ||
+                    pathMatcher.match(contextPath + resource.getPattern(), path));
 
                 if (whitelist && pathMatch && (resource.getMethods() != null && !resource.getMethods().contains(method))) {
                     return true;

--- a/src/main/java/io/gravitee/policy/resourcefiltering/ResourceFilteringPolicy.java
+++ b/src/main/java/io/gravitee/policy/resourcefiltering/ResourceFilteringPolicy.java
@@ -47,7 +47,7 @@ public class ResourceFilteringPolicy extends ResourceFilteringPolicyV3 implement
             final AntPathMatcher pathMatcher = new AntPathMatcher();
             String path = ctx.request().path();
             if (configuration.isNormalizeRequestPath()) {
-                path = PathNormalizer.normalize(path);
+                path = PathNormalizer.normalize(path, configuration.isDecodeEncodedSlash());
             }
             final String contextPath = ctx.request().contextPath();
             final io.gravitee.common.http.HttpMethod method = ctx.request().method();

--- a/src/main/java/io/gravitee/policy/resourcefiltering/ResourceFilteringPolicy.java
+++ b/src/main/java/io/gravitee/policy/resourcefiltering/ResourceFilteringPolicy.java
@@ -15,140 +15,69 @@
  */
 package io.gravitee.policy.resourcefiltering;
 
-import io.gravitee.common.http.HttpMethod;
 import io.gravitee.common.http.HttpStatusCode;
-import io.gravitee.common.util.Maps;
-import io.gravitee.gateway.api.Request;
-import io.gravitee.gateway.api.Response;
-import io.gravitee.policy.api.PolicyChain;
-import io.gravitee.policy.api.PolicyResult;
-import io.gravitee.policy.api.annotations.OnRequest;
-import io.gravitee.policy.resourcefiltering.configuration.Resource;
+import io.gravitee.gateway.api.ExecutionContext;
+import io.gravitee.gateway.reactive.api.ExecutionFailure;
+import io.gravitee.gateway.reactive.api.context.http.HttpPlainExecutionContext;
+import io.gravitee.gateway.reactive.api.policy.http.HttpPolicy;
 import io.gravitee.policy.resourcefiltering.configuration.ResourceFilteringPolicyConfiguration;
-import java.util.List;
+import io.gravitee.policy.v3.resourcefiltering.ResourceFilteringPolicyV3;
+import io.reactivex.rxjava3.core.Completable;
 import org.springframework.util.AntPathMatcher;
-import org.springframework.util.PathMatcher;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)
  * @author GraviteeSource Team
  */
-public class ResourceFilteringPolicy {
+public class ResourceFilteringPolicy extends ResourceFilteringPolicyV3 implements HttpPolicy {
 
-    /**
-     * The associated configuration to this Resource Filtering Policy
-     */
-    private ResourceFilteringPolicyConfiguration configuration;
-
-    private static final String RESOURCE_FILTERING_FORBIDDEN = "RESOURCE_FILTERING_FORBIDDEN";
-    private static final String RESOURCE_FILTERING_METHOD_NOT_ALLOWED = "RESOURCE_FILTERING_METHOD_NOT_ALLOWED";
-
-    /**
-     * Create a new Resource Filtering Policy instance based on its associated configuration
-     *
-     * @param configuration the associated configuration to the new  Resource Filtering Policy instance
-     */
     public ResourceFilteringPolicy(ResourceFilteringPolicyConfiguration configuration) {
-        this.configuration = configuration;
+        super(configuration);
     }
 
-    @OnRequest
-    public void onRequest(Request request, Response response, PolicyChain policyChain) {
-        final AntPathMatcher pathMatcher = new AntPathMatcher();
-
-        if (!match(true, request.contextPath(), configuration.getWhitelist(), request.method(), pathMatcher, request.path())) {
-            if (methodMismatch(true, request.contextPath(), configuration.getWhitelist(), request.method(), pathMatcher, request.path())) {
-                failedOnMethod(request, policyChain);
-            } else {
-                failedOnPath(request, policyChain);
-            }
-            return;
-        } else if (match(false, request.contextPath(), configuration.getBlacklist(), request.method(), pathMatcher, request.path())) {
-            if (methodMismatch(false, request.contextPath(), configuration.getBlacklist(), request.method(), pathMatcher, request.path())) {
-                failedOnMethod(request, policyChain);
-            } else {
-                failedOnPath(request, policyChain);
-            }
-
-            return;
-        }
-
-        policyChain.doNext(request, response);
+    @Override
+    public String id() {
+        return "resource-filtering";
     }
 
-    private void failedOnMethod(Request request, PolicyChain policyChain) {
-        policyChain.failWith(
-            PolicyResult.failure(
-                RESOURCE_FILTERING_METHOD_NOT_ALLOWED,
-                HttpStatusCode.METHOD_NOT_ALLOWED_405,
-                "Method not allowed while accessing this resource",
-                Maps.<String, Object>builder().put("path", request.path()).put("method", request.method()).build()
-            )
-        );
-    }
+    @Override
+    public Completable onRequest(HttpPlainExecutionContext ctx) {
+        return Completable.defer(() -> {
+            final AntPathMatcher pathMatcher = new AntPathMatcher();
+            final String path = ctx.request().path();
+            final String contextPath = ctx.request().contextPath();
+            final io.gravitee.common.http.HttpMethod method = ctx.request().method();
 
-    private void failedOnPath(Request request, PolicyChain policyChain) {
-        policyChain.failWith(
-            PolicyResult.failure(
-                RESOURCE_FILTERING_FORBIDDEN,
-                HttpStatusCode.FORBIDDEN_403,
-                "You're not allowed to access this resource",
-                Maps.<String, Object>builder().put("path", request.path()).put("method", request.method()).build()
-            )
-        );
-    }
-
-    private boolean match(
-        boolean whitelist,
-        String contextPath,
-        List<Resource> resources,
-        HttpMethod method,
-        PathMatcher pathMatcher,
-        String path
-    ) {
-        if (resources == null || resources.isEmpty()) {
-            return whitelist;
-        }
-
-        for (Resource resource : resources) {
-            if (
-                (resource.getMethods() == null || resource.getMethods().isEmpty() || resource.getMethods().contains(method)) &&
-                (resource.getPattern() == null ||
-                    pathMatcher.match(resource.getPattern(), path) ||
-                    pathMatcher.match(contextPath + resource.getPattern(), path))
-            ) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    private boolean methodMismatch(
-        boolean whitelist,
-        String contextPath,
-        List<Resource> resources,
-        HttpMethod method,
-        PathMatcher pathMatcher,
-        String path
-    ) {
-        if (!(resources == null || resources.isEmpty())) {
-            for (Resource resource : resources) {
-                boolean pathMatch = (resource.getPattern() == null ||
-                    pathMatcher.match(resource.getPattern(), path) ||
-                    pathMatcher.match(contextPath + resource.getPattern(), path));
-
-                if (whitelist && pathMatch && (resource.getMethods() != null && !resource.getMethods().contains(method))) {
-                    return true;
+            if (!match(true, contextPath, configuration.getWhitelist(), method, pathMatcher, path)) {
+                if (methodMismatch(true, contextPath, configuration.getWhitelist(), method, pathMatcher, path)) {
+                    return ctx.interruptWith(
+                        new ExecutionFailure(HttpStatusCode.METHOD_NOT_ALLOWED_405)
+                            .key(RESOURCE_FILTERING_METHOD_NOT_ALLOWED)
+                            .message("Method not allowed while accessing this resource")
+                    );
                 }
-
-                if (!whitelist && pathMatch && (resource.getMethods() != null && resource.getMethods().contains(method))) {
-                    return true;
+                return ctx.interruptWith(
+                    new ExecutionFailure(HttpStatusCode.FORBIDDEN_403)
+                        .key(RESOURCE_FILTERING_FORBIDDEN)
+                        .message("You're not allowed to access this resource")
+                );
+            } else if (match(false, contextPath, configuration.getBlacklist(), method, pathMatcher, path)) {
+                if (methodMismatch(false, contextPath, configuration.getBlacklist(), method, pathMatcher, path)) {
+                    return ctx.interruptWith(
+                        new ExecutionFailure(HttpStatusCode.METHOD_NOT_ALLOWED_405)
+                            .key(RESOURCE_FILTERING_METHOD_NOT_ALLOWED)
+                            .message("Method not allowed while accessing this resource")
+                    );
                 }
+                return ctx.interruptWith(
+                    new ExecutionFailure(HttpStatusCode.FORBIDDEN_403)
+                        .key(RESOURCE_FILTERING_FORBIDDEN)
+                        .message("You're not allowed to access this resource")
+                );
             }
-        }
 
-        return false;
+            return Completable.complete();
+        });
     }
 }

--- a/src/main/java/io/gravitee/policy/resourcefiltering/ResourceFilteringPolicy.java
+++ b/src/main/java/io/gravitee/policy/resourcefiltering/ResourceFilteringPolicy.java
@@ -45,7 +45,10 @@ public class ResourceFilteringPolicy extends ResourceFilteringPolicyV3 implement
     public Completable onRequest(HttpPlainExecutionContext ctx) {
         return Completable.defer(() -> {
             final AntPathMatcher pathMatcher = new AntPathMatcher();
-            final String path = ctx.request().path();
+            String path = ctx.request().path();
+            if (configuration.isNormalizeRequestPath()) {
+                path = PathNormalizer.normalize(path);
+            }
             final String contextPath = ctx.request().contextPath();
             final io.gravitee.common.http.HttpMethod method = ctx.request().method();
 

--- a/src/main/java/io/gravitee/policy/resourcefiltering/configuration/Resource.java
+++ b/src/main/java/io/gravitee/policy/resourcefiltering/configuration/Resource.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/policy/resourcefiltering/configuration/ResourceFilteringPolicyConfiguration.java
+++ b/src/main/java/io/gravitee/policy/resourcefiltering/configuration/ResourceFilteringPolicyConfiguration.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/policy/resourcefiltering/configuration/ResourceFilteringPolicyConfiguration.java
+++ b/src/main/java/io/gravitee/policy/resourcefiltering/configuration/ResourceFilteringPolicyConfiguration.java
@@ -33,6 +33,9 @@ public class ResourceFilteringPolicyConfiguration implements PolicyConfiguration
     @JsonProperty("blacklist")
     private List<Resource> blacklist;
 
+    @JsonProperty("normalizeRequestPath")
+    private Boolean normalizeRequestPath;
+
     public List<Resource> getWhitelist() {
         return whitelist;
     }
@@ -47,5 +50,13 @@ public class ResourceFilteringPolicyConfiguration implements PolicyConfiguration
 
     public void setBlacklist(List<Resource> blacklist) {
         this.blacklist = blacklist;
+    }
+
+    public boolean isNormalizeRequestPath() {
+        return normalizeRequestPath != null && normalizeRequestPath;
+    }
+
+    public void setNormalizeRequestPath(Boolean normalizeRequestPath) {
+        this.normalizeRequestPath = normalizeRequestPath;
     }
 }

--- a/src/main/java/io/gravitee/policy/resourcefiltering/configuration/ResourceFilteringPolicyConfiguration.java
+++ b/src/main/java/io/gravitee/policy/resourcefiltering/configuration/ResourceFilteringPolicyConfiguration.java
@@ -36,6 +36,9 @@ public class ResourceFilteringPolicyConfiguration implements PolicyConfiguration
     @JsonProperty("normalizeRequestPath")
     private Boolean normalizeRequestPath;
 
+    @JsonProperty("decodeEncodedSlash")
+    private Boolean decodeEncodedSlash;
+
     public List<Resource> getWhitelist() {
         return whitelist;
     }
@@ -58,5 +61,13 @@ public class ResourceFilteringPolicyConfiguration implements PolicyConfiguration
 
     public void setNormalizeRequestPath(Boolean normalizeRequestPath) {
         this.normalizeRequestPath = normalizeRequestPath;
+    }
+
+    public boolean isDecodeEncodedSlash() {
+        return decodeEncodedSlash != null && decodeEncodedSlash;
+    }
+
+    public void setDecodeEncodedSlash(Boolean decodeEncodedSlash) {
+        this.decodeEncodedSlash = decodeEncodedSlash;
     }
 }

--- a/src/main/java/io/gravitee/policy/v3/resourcefiltering/ResourceFilteringPolicyV3.java
+++ b/src/main/java/io/gravitee/policy/v3/resourcefiltering/ResourceFilteringPolicyV3.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.v3.resourcefiltering;
+
+import io.gravitee.common.http.HttpMethod;
+import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.common.util.Maps;
+import io.gravitee.gateway.api.Request;
+import io.gravitee.gateway.api.Response;
+import io.gravitee.policy.api.PolicyChain;
+import io.gravitee.policy.api.PolicyResult;
+import io.gravitee.policy.api.annotations.OnRequest;
+import io.gravitee.policy.resourcefiltering.configuration.Resource;
+import io.gravitee.policy.resourcefiltering.configuration.ResourceFilteringPolicyConfiguration;
+import java.util.List;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.util.PathMatcher;
+
+/**
+ * @author David BRASSELY (david.brassely at graviteesource.com)
+ * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class ResourceFilteringPolicyV3 {
+
+    protected static final String RESOURCE_FILTERING_FORBIDDEN = "RESOURCE_FILTERING_FORBIDDEN";
+    protected static final String RESOURCE_FILTERING_METHOD_NOT_ALLOWED = "RESOURCE_FILTERING_METHOD_NOT_ALLOWED";
+
+    protected final ResourceFilteringPolicyConfiguration configuration;
+
+    public ResourceFilteringPolicyV3(ResourceFilteringPolicyConfiguration configuration) {
+        this.configuration = configuration;
+    }
+
+    @OnRequest
+    public void onRequest(Request request, Response response, PolicyChain policyChain) {
+        final AntPathMatcher pathMatcher = new AntPathMatcher();
+
+        if (!match(true, request.contextPath(), configuration.getWhitelist(), request.method(), pathMatcher, request.path())) {
+            if (methodMismatch(true, request.contextPath(), configuration.getWhitelist(), request.method(), pathMatcher, request.path())) {
+                failedOnMethod(request, policyChain);
+            } else {
+                failedOnPath(request, policyChain);
+            }
+            return;
+        } else if (match(false, request.contextPath(), configuration.getBlacklist(), request.method(), pathMatcher, request.path())) {
+            if (methodMismatch(false, request.contextPath(), configuration.getBlacklist(), request.method(), pathMatcher, request.path())) {
+                failedOnMethod(request, policyChain);
+            } else {
+                failedOnPath(request, policyChain);
+            }
+
+            return;
+        }
+
+        policyChain.doNext(request, response);
+    }
+
+    private void failedOnMethod(Request request, PolicyChain policyChain) {
+        policyChain.failWith(
+            PolicyResult.failure(
+                RESOURCE_FILTERING_METHOD_NOT_ALLOWED,
+                HttpStatusCode.METHOD_NOT_ALLOWED_405,
+                "Method not allowed while accessing this resource",
+                Maps.<String, Object>builder().put("path", request.path()).put("method", request.method()).build()
+            )
+        );
+    }
+
+    private void failedOnPath(Request request, PolicyChain policyChain) {
+        policyChain.failWith(
+            PolicyResult.failure(
+                RESOURCE_FILTERING_FORBIDDEN,
+                HttpStatusCode.FORBIDDEN_403,
+                "You're not allowed to access this resource",
+                Maps.<String, Object>builder().put("path", request.path()).put("method", request.method()).build()
+            )
+        );
+    }
+
+    protected static boolean match(
+        boolean whitelist,
+        String contextPath,
+        List<Resource> resources,
+        HttpMethod method,
+        PathMatcher pathMatcher,
+        String path
+    ) {
+        if (resources == null || resources.isEmpty()) {
+            return whitelist;
+        }
+
+        for (Resource resource : resources) {
+            if (
+                (resource.getMethods() == null || resource.getMethods().isEmpty() || resource.getMethods().contains(method)) &&
+                (resource.getPattern() == null ||
+                    pathMatcher.match(resource.getPattern(), path) ||
+                    pathMatcher.match(contextPath + resource.getPattern(), path))
+            ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    protected static boolean methodMismatch(
+        boolean whitelist,
+        String contextPath,
+        List<Resource> resources,
+        HttpMethod method,
+        PathMatcher pathMatcher,
+        String path
+    ) {
+        if (!(resources == null || resources.isEmpty())) {
+            for (Resource resource : resources) {
+                boolean pathMatch = (resource.getPattern() == null ||
+                    pathMatcher.match(resource.getPattern(), path) ||
+                    pathMatcher.match(contextPath + resource.getPattern(), path));
+
+                if (whitelist && pathMatch && (resource.getMethods() != null && !resource.getMethods().contains(method))) {
+                    return true;
+                }
+
+                if (!whitelist && pathMatch && (resource.getMethods() != null && resource.getMethods().contains(method))) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/main/java/io/gravitee/policy/v3/resourcefiltering/ResourceFilteringPolicyV3.java
+++ b/src/main/java/io/gravitee/policy/v3/resourcefiltering/ResourceFilteringPolicyV3.java
@@ -23,6 +23,7 @@ import io.gravitee.gateway.api.Response;
 import io.gravitee.policy.api.PolicyChain;
 import io.gravitee.policy.api.PolicyResult;
 import io.gravitee.policy.api.annotations.OnRequest;
+import io.gravitee.policy.resourcefiltering.PathNormalizer;
 import io.gravitee.policy.resourcefiltering.configuration.Resource;
 import io.gravitee.policy.resourcefiltering.configuration.ResourceFilteringPolicyConfiguration;
 import java.util.List;
@@ -49,15 +50,20 @@ public class ResourceFilteringPolicyV3 {
     public void onRequest(Request request, Response response, PolicyChain policyChain) {
         final AntPathMatcher pathMatcher = new AntPathMatcher();
 
-        if (!match(true, request.contextPath(), configuration.getWhitelist(), request.method(), pathMatcher, request.path())) {
-            if (methodMismatch(true, request.contextPath(), configuration.getWhitelist(), request.method(), pathMatcher, request.path())) {
+        String path = request.path();
+        if (configuration.isNormalizeRequestPath()) {
+            path = PathNormalizer.normalize(path);
+        }
+
+        if (!match(true, request.contextPath(), configuration.getWhitelist(), request.method(), pathMatcher, path)) {
+            if (methodMismatch(true, request.contextPath(), configuration.getWhitelist(), request.method(), pathMatcher, path)) {
                 failedOnMethod(request, policyChain);
             } else {
                 failedOnPath(request, policyChain);
             }
             return;
-        } else if (match(false, request.contextPath(), configuration.getBlacklist(), request.method(), pathMatcher, request.path())) {
-            if (methodMismatch(false, request.contextPath(), configuration.getBlacklist(), request.method(), pathMatcher, request.path())) {
+        } else if (match(false, request.contextPath(), configuration.getBlacklist(), request.method(), pathMatcher, path)) {
+            if (methodMismatch(false, request.contextPath(), configuration.getBlacklist(), request.method(), pathMatcher, path)) {
                 failedOnMethod(request, policyChain);
             } else {
                 failedOnPath(request, policyChain);

--- a/src/main/java/io/gravitee/policy/v3/resourcefiltering/ResourceFilteringPolicyV3.java
+++ b/src/main/java/io/gravitee/policy/v3/resourcefiltering/ResourceFilteringPolicyV3.java
@@ -52,7 +52,7 @@ public class ResourceFilteringPolicyV3 {
 
         String path = request.path();
         if (configuration.isNormalizeRequestPath()) {
-            path = PathNormalizer.normalize(path);
+            path = PathNormalizer.normalize(path, configuration.isDecodeEncodedSlash());
         }
 
         if (!match(true, request.contextPath(), configuration.getWhitelist(), request.method(), pathMatcher, path)) {

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -35,6 +35,12 @@
             "type": "boolean",
             "default": false
         },
+        "decodeEncodedSlash": {
+            "title": "Decode encoded slashes (%2F)",
+            "description": "Only applies when path normalization is enabled. When enabled, encoded slashes (%2F/%2f) are decoded to '/' during normalization. When disabled (default), they are preserved as literal %2F/%2f so that legitimate uses (e.g. identifiers containing a slash) are not altered. Enable for stricter security at the cost of rejecting paths that legitimately contain encoded slashes.",
+            "type": "boolean",
+            "default": false
+        },
         "blacklist": {
             "title": "Blacklist",
             "type": "array",

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -29,6 +29,12 @@
                 "required": ["pattern"]
             }
         },
+        "normalizeRequestPath": {
+            "title": "Normalize request path",
+            "description": "When enabled, the request path is normalized before evaluation (URL-decode, resolve dot segments, collapse double slashes). This prevents bypass via encoded paths.",
+            "type": "boolean",
+            "default": false
+        },
         "blacklist": {
             "title": "Blacklist",
             "type": "array",

--- a/src/test/java/io/gravitee/policy/resourcefiltering/PathNormalizerTest.java
+++ b/src/test/java/io/gravitee/policy/resourcefiltering/PathNormalizerTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.resourcefiltering;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+
+class PathNormalizerTest {
+
+    @Test
+    void should_return_null_for_null_path() {
+        assertNull(PathNormalizer.normalize(null));
+    }
+
+    @Test
+    void should_return_empty_for_empty_path() {
+        assertEquals("", PathNormalizer.normalize(""));
+    }
+
+    @Test
+    void should_not_change_clean_path() {
+        assertEquals("/admin/test", PathNormalizer.normalize("/admin/test"));
+    }
+
+    @Test
+    void should_decode_url_encoded_characters() {
+        assertEquals("/admin/test", PathNormalizer.normalize("/admi%6e/test"));
+    }
+
+    @Test
+    void should_decode_multiple_encoded_characters() {
+        assertEquals("/admin/test.php", PathNormalizer.normalize("/%61dmin/%74est.php"));
+    }
+
+    @Test
+    void should_collapse_double_slashes() {
+        assertEquals("/admin/test", PathNormalizer.normalize("/admin//test"));
+    }
+
+    @Test
+    void should_collapse_triple_slashes() {
+        assertEquals("/admin/test", PathNormalizer.normalize("/admin///test"));
+    }
+
+    @Test
+    void should_resolve_dot_segments() {
+        assertEquals("/admin/test", PathNormalizer.normalize("/admin/./test"));
+    }
+
+    @Test
+    void should_resolve_parent_traversal() {
+        assertEquals("/admin/test", PathNormalizer.normalize("/admin/../admin/test"));
+    }
+
+    @Test
+    void should_resolve_parent_traversal_at_root() {
+        assertEquals("/secret/test", PathNormalizer.normalize("/api/../secret/test"));
+    }
+
+    @Test
+    void should_handle_combined_attack_vectors() {
+        assertEquals("/admin/test", PathNormalizer.normalize("/admi%6e/./test"));
+    }
+
+    @Test
+    void should_handle_encoding_and_double_slash() {
+        assertEquals("/admin/test", PathNormalizer.normalize("/admi%6e//test"));
+    }
+
+    @Test
+    void should_preserve_trailing_slash() {
+        assertEquals("/admin/test/", PathNormalizer.normalize("/admin/test/"));
+    }
+
+    @Test
+    void should_handle_root_path() {
+        assertEquals("/", PathNormalizer.normalize("/"));
+    }
+}

--- a/src/test/java/io/gravitee/policy/resourcefiltering/PathNormalizerTest.java
+++ b/src/test/java/io/gravitee/policy/resourcefiltering/PathNormalizerTest.java
@@ -91,4 +91,42 @@ class PathNormalizerTest {
     void should_handle_root_path() {
         assertEquals("/", PathNormalizer.normalize("/"));
     }
+
+    @Test
+    void should_preserve_encoded_slash_by_default() {
+        assertEquals("/api/users/alice%2Fbob", PathNormalizer.normalize("/api/users/alice%2Fbob"));
+    }
+
+    @Test
+    void should_preserve_lowercase_encoded_slash_by_default() {
+        assertEquals("/api/users/alice%2fbob", PathNormalizer.normalize("/api/users/alice%2fbob"));
+    }
+
+    @Test
+    void should_preserve_encoded_slash_and_still_decode_other_encodings() {
+        assertEquals("/admin/alice%2Fbob", PathNormalizer.normalize("/admi%6e/alice%2Fbob"));
+    }
+
+    @Test
+    void should_not_resolve_dot_segments_hidden_behind_encoded_slash_by_default() {
+        // %2F stays literal, so the "/.." is not a real path segment and is not resolved.
+        assertEquals("/api/users/alice%2F..%2Fadmin", PathNormalizer.normalize("/api/users/alice%2F..%2Fadmin"));
+    }
+
+    @Test
+    void should_decode_encoded_slash_when_enabled() {
+        assertEquals("/api/users/alice/bob", PathNormalizer.normalize("/api/users/alice%2Fbob", true));
+    }
+
+    @Test
+    void should_decode_lowercase_encoded_slash_when_enabled() {
+        assertEquals("/api/users/alice/bob", PathNormalizer.normalize("/api/users/alice%2fbob", true));
+    }
+
+    @Test
+    void should_resolve_dot_segments_hidden_behind_encoded_slash_when_enabled() {
+        // %2F becomes /, dot segments are then resolved, revealing the bypass attempt:
+        // /api/users/alice/../admin -> /api/users/admin
+        assertEquals("/api/users/admin", PathNormalizer.normalize("/api/users/alice%2F..%2Fadmin", true));
+    }
 }

--- a/src/test/java/io/gravitee/policy/resourcefiltering/ResourceFilteringPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/resourcefiltering/ResourceFilteringPolicyTest.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/io/gravitee/policy/resourcefiltering/ResourceFilteringPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/resourcefiltering/ResourceFilteringPolicyTest.java
@@ -15,8 +15,8 @@
  */
 package io.gravitee.policy.resourcefiltering;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -32,20 +32,20 @@ import io.gravitee.policy.resourcefiltering.configuration.ResourceFilteringPolic
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)
  * @author GraviteeSource Team
  */
-@RunWith(MockitoJUnitRunner.class)
-public class ResourceFilteringPolicyTest {
+@ExtendWith(MockitoExtension.class)
+class ResourceFilteringPolicyTest {
 
     private ResourceFilteringPolicy resourceFilteringPolicy;
 
@@ -61,13 +61,13 @@ public class ResourceFilteringPolicyTest {
     @Mock
     protected PolicyChain policyChain;
 
-    @Before
-    public void init() {
+    @BeforeEach
+    void init() {
         resourceFilteringPolicy = new ResourceFilteringPolicy(resourceFilteringPolicyConfiguration);
     }
 
     @Test
-    public void testOnRequest_noFiltering() {
+    void testOnRequest_noFiltering() {
         when(resourceFilteringPolicyConfiguration.getBlacklist()).thenReturn(null);
         when(resourceFilteringPolicyConfiguration.getWhitelist()).thenReturn(null);
 
@@ -79,7 +79,7 @@ public class ResourceFilteringPolicyTest {
     }
 
     @Test
-    public void testOnRequest_emptyFiltering() {
+    void testOnRequest_emptyFiltering() {
         when(resourceFilteringPolicyConfiguration.getBlacklist()).thenReturn(new ArrayList<>());
         when(resourceFilteringPolicyConfiguration.getWhitelist()).thenReturn(new ArrayList<>());
 
@@ -91,7 +91,7 @@ public class ResourceFilteringPolicyTest {
     }
 
     @Test
-    public void testOnRequest_singleWhitelistFiltering() {
+    void testOnRequest_singleWhitelistFiltering() {
         Resource resource = new Resource();
         resource.setPattern("/**");
 
@@ -105,7 +105,7 @@ public class ResourceFilteringPolicyTest {
     }
 
     @Test
-    public void testOnRequest_singleBlacklistFiltering() {
+    void testOnRequest_singleBlacklistFiltering() {
         Resource resource = new Resource();
         resource.setPattern("/**");
 
@@ -119,7 +119,7 @@ public class ResourceFilteringPolicyTest {
     }
 
     @Test
-    public void testOnRequest_singleBlacklistFiltering_withContextPath() {
+    void testOnRequest_singleBlacklistFiltering_withContextPath() {
         Resource resource = new Resource();
         resource.setPattern("/**");
 
@@ -133,7 +133,7 @@ public class ResourceFilteringPolicyTest {
     }
 
     @Test
-    public void testOnRequest_singleWhitelistWithMethodFiltering() {
+    void testOnRequest_singleWhitelistWithMethodFiltering() {
         Resource resource = new Resource();
         resource.setPattern("/**");
         resource.setMethods(Collections.singletonList(HttpMethod.GET));
@@ -143,20 +143,20 @@ public class ResourceFilteringPolicyTest {
         when(request.contextPath()).thenReturn("/products/123456/");
         when(request.method()).thenReturn(HttpMethod.POST);
 
-        ArgumentCaptor<PolicyResult> poilcyResultCaptor = ArgumentCaptor.forClass(PolicyResult.class);
+        ArgumentCaptor<PolicyResult> policyResultCaptor = ArgumentCaptor.forClass(PolicyResult.class);
 
         resourceFilteringPolicy.onRequest(request, response, policyChain);
 
-        verify(policyChain).failWith(poilcyResultCaptor.capture());
+        verify(policyChain).failWith(policyResultCaptor.capture());
 
-        final PolicyResult value = poilcyResultCaptor.getValue();
+        final PolicyResult value = policyResultCaptor.getValue();
         assertNotNull(value);
         assertEquals(HttpStatusCode.METHOD_NOT_ALLOWED_405, value.statusCode());
         assertEquals("RESOURCE_FILTERING_METHOD_NOT_ALLOWED", value.key());
     }
 
     @Test
-    public void testOnRequest_singleWhitelistWithMethodFiltering2() {
+    void testOnRequest_singleWhitelistWithMethodFiltering2() {
         Resource resource = new Resource();
         resource.setPattern("/**");
         resource.setMethods(Collections.singletonList(HttpMethod.GET));
@@ -172,7 +172,7 @@ public class ResourceFilteringPolicyTest {
     }
 
     @Test
-    public void testOnRequest_singleBlacklistWithMethodFiltering() {
+    void testOnRequest_singleBlacklistWithMethodFiltering() {
         Resource resource = new Resource();
         resource.setPattern("/**");
         resource.setMethods(Collections.singletonList(HttpMethod.GET));
@@ -188,7 +188,7 @@ public class ResourceFilteringPolicyTest {
     }
 
     @Test
-    public void testOnRequest_singleBlacklistWithMethodFiltering2() {
+    void testOnRequest_singleBlacklistWithMethodFiltering2() {
         Resource resource = new Resource();
         resource.setPattern("/**");
         resource.setMethods(Collections.singletonList(HttpMethod.GET));
@@ -204,7 +204,7 @@ public class ResourceFilteringPolicyTest {
     }
 
     @Test
-    public void testOnRequest_antPatternFiltering() {
+    void testOnRequest_antPatternFiltering() {
         Resource resource = new Resource();
         resource.setPattern("/*");
 
@@ -218,7 +218,7 @@ public class ResourceFilteringPolicyTest {
     }
 
     @Test
-    public void testOnRequest_antPatternFiltering_withContextPath() {
+    void testOnRequest_antPatternFiltering_withContextPath() {
         Resource resource = new Resource();
         resource.setPattern("/*");
 
@@ -232,7 +232,7 @@ public class ResourceFilteringPolicyTest {
     }
 
     @Test
-    public void testOnRequest_antPatternFiltering2() {
+    void testOnRequest_antPatternFiltering2() {
         Resource resource = new Resource();
         resource.setPattern("/products/*");
 
@@ -246,7 +246,7 @@ public class ResourceFilteringPolicyTest {
     }
 
     @Test
-    public void testOnRequest_antPatternFiltering2_withContextPath() {
+    void testOnRequest_antPatternFiltering2_withContextPath() {
         Resource resource = new Resource();
         resource.setPattern("/*");
 
@@ -260,7 +260,7 @@ public class ResourceFilteringPolicyTest {
     }
 
     @Test
-    public void testOnRequest_antPatternFiltering3() {
+    void testOnRequest_antPatternFiltering3() {
         Resource resource = new Resource();
         resource.setPattern("/products/**/prices");
 
@@ -274,7 +274,7 @@ public class ResourceFilteringPolicyTest {
     }
 
     @Test
-    public void testOnRequest_antPatternFiltering3_withContextPath() {
+    void testOnRequest_antPatternFiltering3_withContextPath() {
         Resource resource = new Resource();
         resource.setPattern("/**/prices");
 
@@ -288,7 +288,7 @@ public class ResourceFilteringPolicyTest {
     }
 
     @Test
-    public void testOnRequest_antPatternFiltering4() {
+    void testOnRequest_antPatternFiltering4() {
         Resource resource = new Resource();
         resource.setPattern("/products/**/prices");
 
@@ -302,7 +302,7 @@ public class ResourceFilteringPolicyTest {
     }
 
     @Test
-    public void testOnRequest_antPatternFiltering4_withContextPath() {
+    void testOnRequest_antPatternFiltering4_withContextPath() {
         Resource resource = new Resource();
         resource.setPattern("/**/prices");
 
@@ -316,7 +316,7 @@ public class ResourceFilteringPolicyTest {
     }
 
     @Test
-    public void testOnRequest_antPatternFiltering5() {
+    void testOnRequest_antPatternFiltering5() {
         Resource resource = new Resource();
         resource.setPattern("/products/**/prices");
 
@@ -330,7 +330,7 @@ public class ResourceFilteringPolicyTest {
     }
 
     @Test
-    public void testOnRequest_antPatternFiltering5_withContextPath() {
+    void testOnRequest_antPatternFiltering5_withContextPath() {
         Resource resource = new Resource();
         resource.setPattern("/**/prices");
 
@@ -344,7 +344,7 @@ public class ResourceFilteringPolicyTest {
     }
 
     @Test
-    public void testOnRequest_antPatternFiltering6() {
+    void testOnRequest_antPatternFiltering6() {
         Resource resource = new Resource();
         resource.setPattern("/products/**/prices/*");
 
@@ -358,7 +358,7 @@ public class ResourceFilteringPolicyTest {
     }
 
     @Test
-    public void testOnRequest_antPatternFiltering6_withContextPath() {
+    void testOnRequest_antPatternFiltering6_withContextPath() {
         Resource resource = new Resource();
         resource.setPattern("/**/prices/*");
 
@@ -372,7 +372,7 @@ public class ResourceFilteringPolicyTest {
     }
 
     @Test
-    public void testOnRequest_antPatternFiltering7_withContextPath_multipleResources_ok_ko() {
+    void testOnRequest_antPatternFiltering7_withContextPath_multipleResources_ok_ko() {
         Resource resource1 = new Resource();
         resource1.setPattern("/**/prices/*");
         Resource resource2 = new Resource();
@@ -388,7 +388,7 @@ public class ResourceFilteringPolicyTest {
     }
 
     @Test
-    public void testOnRequest_antPatternFiltering8_withContextPath_multipleResources_ko_ok() {
+    void testOnRequest_antPatternFiltering8_withContextPath_multipleResources_ko_ok() {
         Resource resource1 = new Resource();
         resource1.setPattern("/**/prices/*");
         Resource resource2 = new Resource();

--- a/src/test/java/io/gravitee/policy/resourcefiltering/ResourceFilteringPolicyV4Test.java
+++ b/src/test/java/io/gravitee/policy/resourcefiltering/ResourceFilteringPolicyV4Test.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.resourcefiltering;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.common.http.HttpMethod;
+import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.gateway.reactive.api.context.http.HttpPlainExecutionContext;
+import io.gravitee.gateway.reactive.api.context.http.HttpPlainRequest;
+import io.gravitee.policy.resourcefiltering.configuration.Resource;
+import io.gravitee.policy.resourcefiltering.configuration.ResourceFilteringPolicyConfiguration;
+import io.reactivex.rxjava3.core.Completable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ResourceFilteringPolicyV4Test {
+
+    @Mock
+    private ResourceFilteringPolicyConfiguration configuration;
+
+    @Mock
+    private HttpPlainExecutionContext ctx;
+
+    @Mock
+    private HttpPlainRequest request;
+
+    private ResourceFilteringPolicy policy;
+
+    @BeforeEach
+    void setUp() {
+        policy = new ResourceFilteringPolicy(configuration);
+        lenient().when(ctx.request()).thenReturn(request);
+        lenient().when(ctx.interruptWith(any())).thenReturn(Completable.error(new InterruptedException()));
+    }
+
+    // --- No filtering ---
+
+    @Test
+    void should_continue_when_no_filtering() {
+        when(configuration.getWhitelist()).thenReturn(null);
+        when(configuration.getBlacklist()).thenReturn(null);
+        when(request.path()).thenReturn("/path");
+
+        policy.onRequest(ctx).test().assertComplete();
+    }
+
+    @Test
+    void should_continue_when_empty_filtering() {
+        when(configuration.getWhitelist()).thenReturn(new ArrayList<>());
+        when(configuration.getBlacklist()).thenReturn(new ArrayList<>());
+        when(request.path()).thenReturn("/path");
+
+        policy.onRequest(ctx).test().assertComplete();
+    }
+
+    // --- Whitelist ---
+
+    @Test
+    void should_allow_when_path_matches_whitelist() {
+        Resource resource = new Resource();
+        resource.setPattern("/**");
+
+        when(configuration.getWhitelist()).thenReturn(Collections.singletonList(resource));
+        when(request.path()).thenReturn("/products/123");
+        when(request.contextPath()).thenReturn("/products/123/");
+
+        policy.onRequest(ctx).test().assertComplete();
+    }
+
+    @Test
+    void should_deny_when_path_does_not_match_whitelist() {
+        Resource resource = new Resource();
+        resource.setPattern("/allowed/**");
+
+        when(configuration.getWhitelist()).thenReturn(Collections.singletonList(resource));
+        when(request.path()).thenReturn("/forbidden/data");
+        when(request.contextPath()).thenReturn("/");
+
+        policy.onRequest(ctx).test().assertError(InterruptedException.class);
+
+        verify(ctx).interruptWith(argThat(failure -> failure.statusCode() == HttpStatusCode.FORBIDDEN_403));
+    }
+
+    @Test
+    void should_deny_with_405_when_method_mismatch_on_whitelist() {
+        Resource resource = new Resource();
+        resource.setPattern("/**");
+        resource.setMethods(Collections.singletonList(HttpMethod.GET));
+
+        when(configuration.getWhitelist()).thenReturn(Collections.singletonList(resource));
+        when(request.path()).thenReturn("/products/123");
+        when(request.contextPath()).thenReturn("/products/123/");
+        when(request.method()).thenReturn(HttpMethod.POST);
+
+        policy.onRequest(ctx).test().assertError(InterruptedException.class);
+
+        verify(ctx).interruptWith(argThat(failure -> failure.statusCode() == HttpStatusCode.METHOD_NOT_ALLOWED_405));
+    }
+
+    @Test
+    void should_allow_when_method_matches_whitelist() {
+        Resource resource = new Resource();
+        resource.setPattern("/**");
+        resource.setMethods(Collections.singletonList(HttpMethod.GET));
+
+        when(configuration.getWhitelist()).thenReturn(Collections.singletonList(resource));
+        when(request.path()).thenReturn("/products/123");
+        when(request.contextPath()).thenReturn("/products/123/");
+        when(request.method()).thenReturn(HttpMethod.GET);
+
+        policy.onRequest(ctx).test().assertComplete();
+    }
+
+    // --- Blacklist ---
+
+    @Test
+    void should_deny_when_path_matches_blacklist() {
+        Resource resource = new Resource();
+        resource.setPattern("/admin/**");
+
+        when(configuration.getBlacklist()).thenReturn(Collections.singletonList(resource));
+        when(request.path()).thenReturn("/admin/secret");
+        when(request.contextPath()).thenReturn("/");
+
+        policy.onRequest(ctx).test().assertError(InterruptedException.class);
+
+        verify(ctx).interruptWith(argThat(failure -> failure.statusCode() == HttpStatusCode.FORBIDDEN_403));
+    }
+
+    @Test
+    void should_allow_when_path_does_not_match_blacklist() {
+        Resource resource = new Resource();
+        resource.setPattern("/admin/**");
+
+        when(configuration.getBlacklist()).thenReturn(Collections.singletonList(resource));
+        when(request.path()).thenReturn("/public/data");
+        when(request.contextPath()).thenReturn("/");
+
+        policy.onRequest(ctx).test().assertComplete();
+    }
+
+    @Test
+    void should_deny_with_405_when_method_matches_blacklist() {
+        Resource resource = new Resource();
+        resource.setPattern("/**");
+        resource.setMethods(Collections.singletonList(HttpMethod.DELETE));
+
+        when(configuration.getBlacklist()).thenReturn(Collections.singletonList(resource));
+        when(request.path()).thenReturn("/products/123");
+        when(request.contextPath()).thenReturn("/");
+        when(request.method()).thenReturn(HttpMethod.DELETE);
+
+        policy.onRequest(ctx).test().assertError(InterruptedException.class);
+
+        verify(ctx).interruptWith(argThat(failure -> failure.statusCode() == HttpStatusCode.METHOD_NOT_ALLOWED_405));
+    }
+
+    @Test
+    void should_allow_when_method_does_not_match_blacklist() {
+        Resource resource = new Resource();
+        resource.setPattern("/**");
+        resource.setMethods(Collections.singletonList(HttpMethod.GET));
+
+        when(configuration.getBlacklist()).thenReturn(Collections.singletonList(resource));
+        when(request.path()).thenReturn("/products/123");
+        when(request.contextPath()).thenReturn("/");
+        when(request.method()).thenReturn(HttpMethod.POST);
+
+        policy.onRequest(ctx).test().assertComplete();
+    }
+
+    // --- Ant patterns with context path ---
+
+    @Test
+    void should_deny_with_context_path_pattern() {
+        Resource resource = new Resource();
+        resource.setPattern("/**/prices");
+
+        when(configuration.getBlacklist()).thenReturn(Collections.singletonList(resource));
+        when(request.path()).thenReturn("/products/123/store/prices");
+        when(request.contextPath()).thenReturn("/products/");
+
+        policy.onRequest(ctx).test().assertError(InterruptedException.class);
+
+        verify(ctx).interruptWith(argThat(failure -> failure.statusCode() == HttpStatusCode.FORBIDDEN_403));
+    }
+
+    @Test
+    void should_allow_with_context_path_single_level_wildcard() {
+        Resource resource = new Resource();
+        resource.setPattern("/*");
+
+        when(configuration.getWhitelist()).thenReturn(Collections.singletonList(resource));
+        when(request.path()).thenReturn("/products/123");
+        when(request.contextPath()).thenReturn("/products/");
+
+        policy.onRequest(ctx).test().assertComplete();
+    }
+
+    @Test
+    void should_allow_whitelist_with_multiple_resources_first_matches() {
+        Resource resource1 = new Resource();
+        resource1.setPattern("/**/prices/*");
+        Resource resource2 = new Resource();
+        resource2.setPattern("/**/media/*");
+
+        when(configuration.getWhitelist()).thenReturn(Arrays.asList(resource1, resource2));
+        when(request.path()).thenReturn("/products/123/store/prices/toto");
+        when(request.contextPath()).thenReturn("/products/");
+
+        policy.onRequest(ctx).test().assertComplete();
+    }
+
+    @Test
+    void should_allow_whitelist_with_multiple_resources_second_matches() {
+        Resource resource1 = new Resource();
+        resource1.setPattern("/**/prices/*");
+        Resource resource2 = new Resource();
+        resource2.setPattern("/**/media/*");
+
+        when(configuration.getWhitelist()).thenReturn(Arrays.asList(resource2, resource1));
+        when(request.path()).thenReturn("/products/123/store/prices/toto");
+        when(request.contextPath()).thenReturn("/products/");
+
+        policy.onRequest(ctx).test().assertComplete();
+    }
+}

--- a/src/test/java/io/gravitee/policy/resourcefiltering/ResourceFilteringPolicyV4Test.java
+++ b/src/test/java/io/gravitee/policy/resourcefiltering/ResourceFilteringPolicyV4Test.java
@@ -249,4 +249,92 @@ class ResourceFilteringPolicyV4Test {
 
         policy.onRequest(ctx).test().assertComplete();
     }
+
+    // --- Path normalization tests ---
+
+    @Test
+    void should_block_blacklisted_path_with_url_encoding() {
+        Resource resource = new Resource();
+        resource.setPattern("/admin/**");
+
+        when(configuration.getBlacklist()).thenReturn(Collections.singletonList(resource));
+        when(configuration.isNormalizeRequestPath()).thenReturn(true);
+        when(request.path()).thenReturn("/admi%6e/test");
+        when(request.contextPath()).thenReturn("/");
+
+        policy.onRequest(ctx).test().assertError(InterruptedException.class);
+
+        verify(ctx).interruptWith(argThat(failure -> failure.statusCode() == HttpStatusCode.FORBIDDEN_403));
+    }
+
+    @Test
+    void should_block_blacklisted_path_with_double_slash() {
+        Resource resource = new Resource();
+        resource.setPattern("/admin/**");
+
+        when(configuration.getBlacklist()).thenReturn(Collections.singletonList(resource));
+        when(configuration.isNormalizeRequestPath()).thenReturn(true);
+        when(request.path()).thenReturn("/admin//test");
+        when(request.contextPath()).thenReturn("/");
+
+        policy.onRequest(ctx).test().assertError(InterruptedException.class);
+
+        verify(ctx).interruptWith(argThat(failure -> failure.statusCode() == HttpStatusCode.FORBIDDEN_403));
+    }
+
+    @Test
+    void should_block_blacklisted_path_with_dot_segment() {
+        Resource resource = new Resource();
+        resource.setPattern("/admin/**");
+
+        when(configuration.getBlacklist()).thenReturn(Collections.singletonList(resource));
+        when(configuration.isNormalizeRequestPath()).thenReturn(true);
+        when(request.path()).thenReturn("/admin/./test");
+        when(request.contextPath()).thenReturn("/");
+
+        policy.onRequest(ctx).test().assertError(InterruptedException.class);
+
+        verify(ctx).interruptWith(argThat(failure -> failure.statusCode() == HttpStatusCode.FORBIDDEN_403));
+    }
+
+    @Test
+    void should_block_blacklisted_path_with_parent_traversal() {
+        Resource resource = new Resource();
+        resource.setPattern("/admin/**");
+
+        when(configuration.getBlacklist()).thenReturn(Collections.singletonList(resource));
+        when(configuration.isNormalizeRequestPath()).thenReturn(true);
+        when(request.path()).thenReturn("/admin/../admin/test");
+        when(request.contextPath()).thenReturn("/");
+
+        policy.onRequest(ctx).test().assertError(InterruptedException.class);
+
+        verify(ctx).interruptWith(argThat(failure -> failure.statusCode() == HttpStatusCode.FORBIDDEN_403));
+    }
+
+    @Test
+    void should_allow_encoded_whitelist_path_when_normalized() {
+        Resource resource = new Resource();
+        resource.setPattern("/public/**");
+
+        when(configuration.getWhitelist()).thenReturn(Collections.singletonList(resource));
+        when(configuration.isNormalizeRequestPath()).thenReturn(true);
+        when(request.path()).thenReturn("/publi%63/data");
+        when(request.contextPath()).thenReturn("/");
+
+        policy.onRequest(ctx).test().assertComplete();
+    }
+
+    @Test
+    void should_not_normalize_when_disabled() {
+        Resource resource = new Resource();
+        resource.setPattern("/admin/**");
+
+        when(configuration.getBlacklist()).thenReturn(Collections.singletonList(resource));
+        when(configuration.isNormalizeRequestPath()).thenReturn(false);
+        when(request.path()).thenReturn("/admi%6e/test");
+        when(request.contextPath()).thenReturn("/");
+
+        policy.onRequest(ctx).test().assertComplete();
+    }
 }

--- a/src/test/java/io/gravitee/policy/resourcefiltering/configuration/ResourceFilteringPolicyConfigurationTest.java
+++ b/src/test/java/io/gravitee/policy/resourcefiltering/configuration/ResourceFilteringPolicyConfigurationTest.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/io/gravitee/policy/resourcefiltering/configuration/ResourceFilteringPolicyConfigurationTest.java
+++ b/src/test/java/io/gravitee/policy/resourcefiltering/configuration/ResourceFilteringPolicyConfigurationTest.java
@@ -92,6 +92,29 @@ class ResourceFilteringPolicyConfigurationTest {
         assertFalse(configuration.isNormalizeRequestPath());
     }
 
+    @Test
+    void decodeEncodedSlash_should_default_to_false_when_absent() {
+        ResourceFilteringPolicyConfiguration configuration = new ResourceFilteringPolicyConfiguration();
+
+        assertFalse(configuration.isDecodeEncodedSlash());
+    }
+
+    @Test
+    void decodeEncodedSlash_should_return_true_when_explicitly_enabled() {
+        ResourceFilteringPolicyConfiguration configuration = new ResourceFilteringPolicyConfiguration();
+        configuration.setDecodeEncodedSlash(true);
+
+        assertTrue(configuration.isDecodeEncodedSlash());
+    }
+
+    @Test
+    void decodeEncodedSlash_should_return_false_when_explicitly_disabled() {
+        ResourceFilteringPolicyConfiguration configuration = new ResourceFilteringPolicyConfiguration();
+        configuration.setDecodeEncodedSlash(false);
+
+        assertFalse(configuration.isDecodeEncodedSlash());
+    }
+
     private <T> T load(String resource, Class<T> type) throws IOException {
         URL jsonFile = this.getClass().getResource(resource);
         return new ObjectMapper().readValue(jsonFile, type);

--- a/src/test/java/io/gravitee/policy/resourcefiltering/configuration/ResourceFilteringPolicyConfigurationTest.java
+++ b/src/test/java/io/gravitee/policy/resourcefiltering/configuration/ResourceFilteringPolicyConfigurationTest.java
@@ -15,57 +15,58 @@
  */
 package io.gravitee.policy.resourcefiltering.configuration;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.net.URL;
 import java.util.List;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
-public class ResourceFilteringPolicyConfigurationTest {
+class ResourceFilteringPolicyConfigurationTest {
 
     @Test
-    public void test_resourceFiltering01() throws IOException {
+    void test_resourceFiltering01() throws IOException {
         ResourceFilteringPolicyConfiguration configuration = load(
             "/io/gravitee/policy/resourcefiltering/configuration/resourcefiltering01.json",
             ResourceFilteringPolicyConfiguration.class
         );
 
-        Assert.assertNotNull(configuration);
-        Assert.assertNull(configuration.getBlacklist());
-        Assert.assertNotNull(configuration.getWhitelist());
+        assertNotNull(configuration);
+        assertNull(configuration.getBlacklist());
+        assertNotNull(configuration.getWhitelist());
     }
 
     @Test
-    public void test_resourceFiltering02() throws IOException {
+    void test_resourceFiltering02() throws IOException {
         ResourceFilteringPolicyConfiguration configuration = load(
             "/io/gravitee/policy/resourcefiltering/configuration/resourcefiltering02.json",
             ResourceFilteringPolicyConfiguration.class
         );
 
-        Assert.assertNotNull(configuration);
-        Assert.assertNotNull(configuration.getBlacklist());
-        Assert.assertNotNull(configuration.getWhitelist());
+        assertNotNull(configuration);
+        assertNotNull(configuration.getBlacklist());
+        assertNotNull(configuration.getWhitelist());
     }
 
     @Test
-    public void test_resourceFiltering03() throws IOException {
+    void test_resourceFiltering03() throws IOException {
         ResourceFilteringPolicyConfiguration configuration = load(
             "/io/gravitee/policy/resourcefiltering/configuration/resourcefiltering03.json",
             ResourceFilteringPolicyConfiguration.class
         );
 
         List<Resource> whitelist = configuration.getWhitelist();
-        Assert.assertNotNull(whitelist);
-        Assert.assertFalse(whitelist.isEmpty());
+        assertNotNull(whitelist);
+        assertFalse(whitelist.isEmpty());
 
         Resource resource = whitelist.iterator().next();
-        Assert.assertNotNull(resource);
-        Assert.assertNull(resource.getMethods());
+        assertNotNull(resource);
+        assertNull(resource.getMethods());
     }
 
     private <T> T load(String resource, Class<T> type) throws IOException {

--- a/src/test/java/io/gravitee/policy/resourcefiltering/configuration/ResourceFilteringPolicyConfigurationTest.java
+++ b/src/test/java/io/gravitee/policy/resourcefiltering/configuration/ResourceFilteringPolicyConfigurationTest.java
@@ -69,6 +69,29 @@ class ResourceFilteringPolicyConfigurationTest {
         assertNull(resource.getMethods());
     }
 
+    @Test
+    void normalizeRequestPath_should_default_to_false_when_absent() {
+        ResourceFilteringPolicyConfiguration configuration = new ResourceFilteringPolicyConfiguration();
+
+        assertFalse(configuration.isNormalizeRequestPath());
+    }
+
+    @Test
+    void normalizeRequestPath_should_return_true_when_explicitly_enabled() {
+        ResourceFilteringPolicyConfiguration configuration = new ResourceFilteringPolicyConfiguration();
+        configuration.setNormalizeRequestPath(true);
+
+        assertTrue(configuration.isNormalizeRequestPath());
+    }
+
+    @Test
+    void normalizeRequestPath_should_return_false_when_explicitly_disabled() {
+        ResourceFilteringPolicyConfiguration configuration = new ResourceFilteringPolicyConfiguration();
+        configuration.setNormalizeRequestPath(false);
+
+        assertFalse(configuration.isNormalizeRequestPath());
+    }
+
     private <T> T load(String resource, Class<T> type) throws IOException {
         URL jsonFile = this.getClass().getResource(resource);
         return new ObjectMapper().readValue(jsonFile, type);

--- a/src/test/java/io/gravitee/policy/v3/resourcefiltering/ResourceFilteringPolicyV3Test.java
+++ b/src/test/java/io/gravitee/policy/v3/resourcefiltering/ResourceFilteringPolicyV3Test.java
@@ -402,4 +402,96 @@ class ResourceFilteringPolicyV3Test {
 
         verify(policyChain).doNext(request, response);
     }
+
+    // --- Path normalization tests ---
+
+    @Test
+    void should_block_blacklisted_path_with_url_encoding() {
+        Resource resource = new Resource();
+        resource.setPattern("/admin/**");
+
+        when(resourceFilteringPolicyConfiguration.getBlacklist()).thenReturn(Collections.singletonList(resource));
+        when(resourceFilteringPolicyConfiguration.isNormalizeRequestPath()).thenReturn(true);
+        when(request.path()).thenReturn("/admi%6e/test");
+        when(request.contextPath()).thenReturn("/");
+
+        resourceFilteringPolicy.onRequest(request, response, policyChain);
+
+        verify(policyChain).failWith(any(PolicyResult.class));
+    }
+
+    @Test
+    void should_block_blacklisted_path_with_double_slash() {
+        Resource resource = new Resource();
+        resource.setPattern("/admin/**");
+
+        when(resourceFilteringPolicyConfiguration.getBlacklist()).thenReturn(Collections.singletonList(resource));
+        when(resourceFilteringPolicyConfiguration.isNormalizeRequestPath()).thenReturn(true);
+        when(request.path()).thenReturn("/admin//test");
+        when(request.contextPath()).thenReturn("/");
+
+        resourceFilteringPolicy.onRequest(request, response, policyChain);
+
+        verify(policyChain).failWith(any(PolicyResult.class));
+    }
+
+    @Test
+    void should_block_blacklisted_path_with_dot_segment() {
+        Resource resource = new Resource();
+        resource.setPattern("/admin/**");
+
+        when(resourceFilteringPolicyConfiguration.getBlacklist()).thenReturn(Collections.singletonList(resource));
+        when(resourceFilteringPolicyConfiguration.isNormalizeRequestPath()).thenReturn(true);
+        when(request.path()).thenReturn("/admin/./test");
+        when(request.contextPath()).thenReturn("/");
+
+        resourceFilteringPolicy.onRequest(request, response, policyChain);
+
+        verify(policyChain).failWith(any(PolicyResult.class));
+    }
+
+    @Test
+    void should_block_blacklisted_path_with_parent_traversal() {
+        Resource resource = new Resource();
+        resource.setPattern("/admin/**");
+
+        when(resourceFilteringPolicyConfiguration.getBlacklist()).thenReturn(Collections.singletonList(resource));
+        when(resourceFilteringPolicyConfiguration.isNormalizeRequestPath()).thenReturn(true);
+        when(request.path()).thenReturn("/admin/../admin/test");
+        when(request.contextPath()).thenReturn("/");
+
+        resourceFilteringPolicy.onRequest(request, response, policyChain);
+
+        verify(policyChain).failWith(any(PolicyResult.class));
+    }
+
+    @Test
+    void should_allow_encoded_whitelist_path_when_normalized() {
+        Resource resource = new Resource();
+        resource.setPattern("/public/**");
+
+        when(resourceFilteringPolicyConfiguration.getWhitelist()).thenReturn(Collections.singletonList(resource));
+        when(resourceFilteringPolicyConfiguration.isNormalizeRequestPath()).thenReturn(true);
+        when(request.path()).thenReturn("/publi%63/data");
+        when(request.contextPath()).thenReturn("/");
+
+        resourceFilteringPolicy.onRequest(request, response, policyChain);
+
+        verify(policyChain).doNext(request, response);
+    }
+
+    @Test
+    void should_not_normalize_when_disabled() {
+        Resource resource = new Resource();
+        resource.setPattern("/admin/**");
+
+        when(resourceFilteringPolicyConfiguration.getBlacklist()).thenReturn(Collections.singletonList(resource));
+        when(resourceFilteringPolicyConfiguration.isNormalizeRequestPath()).thenReturn(false);
+        when(request.path()).thenReturn("/admi%6e/test");
+        when(request.contextPath()).thenReturn("/");
+
+        resourceFilteringPolicy.onRequest(request, response, policyChain);
+
+        verify(policyChain).doNext(request, response);
+    }
 }

--- a/src/test/java/io/gravitee/policy/v3/resourcefiltering/ResourceFilteringPolicyV3Test.java
+++ b/src/test/java/io/gravitee/policy/v3/resourcefiltering/ResourceFilteringPolicyV3Test.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.policy.resourcefiltering;
+package io.gravitee.policy.v3.resourcefiltering;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -45,9 +45,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
  * @author GraviteeSource Team
  */
 @ExtendWith(MockitoExtension.class)
-class ResourceFilteringPolicyTest {
+class ResourceFilteringPolicyV3Test {
 
-    private ResourceFilteringPolicy resourceFilteringPolicy;
+    private ResourceFilteringPolicyV3 resourceFilteringPolicy;
 
     @Mock
     private ResourceFilteringPolicyConfiguration resourceFilteringPolicyConfiguration;
@@ -63,7 +63,7 @@ class ResourceFilteringPolicyTest {
 
     @BeforeEach
     void init() {
-        resourceFilteringPolicy = new ResourceFilteringPolicy(resourceFilteringPolicyConfiguration);
+        resourceFilteringPolicy = new ResourceFilteringPolicyV3(resourceFilteringPolicyConfiguration);
     }
 
     @Test

--- a/src/test/resources/io/gravitee/policy/resourcefiltering/configuration/resourcefiltering01.json
+++ b/src/test/resources/io/gravitee/policy/resourcefiltering/configuration/resourcefiltering01.json
@@ -1,5 +1,3 @@
 {
-  "whitelist": [
-
-  ]
+    "whitelist": []
 }

--- a/src/test/resources/io/gravitee/policy/resourcefiltering/configuration/resourcefiltering02.json
+++ b/src/test/resources/io/gravitee/policy/resourcefiltering/configuration/resourcefiltering02.json
@@ -1,8 +1,4 @@
 {
-  "whitelist": [
-
-  ],
-  "blacklist": [
-
-  ]
+    "whitelist": [],
+    "blacklist": []
 }

--- a/src/test/resources/io/gravitee/policy/resourcefiltering/configuration/resourcefiltering03.json
+++ b/src/test/resources/io/gravitee/policy/resourcefiltering/configuration/resourcefiltering03.json
@@ -1,7 +1,7 @@
 {
-  "whitelist": [
-    {
-      "pattern": "/"
-    }
-  ]
+    "whitelist": [
+        {
+            "pattern": "/"
+        }
+    ]
 }

--- a/src/test/resources/io/gravitee/policy/resourcefiltering/configuration/resourcefiltering04.json
+++ b/src/test/resources/io/gravitee/policy/resourcefiltering/configuration/resourcefiltering04.json
@@ -1,8 +1,7 @@
 {
-  "whitelist": [
-    {
-      "path": "/",
-
-    }
-  ]
+    "whitelist": [
+        {
+            "path": "/"
+        }
+    ]
 }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-13563

**Description**

***normalizeRequestPath***
Normalize the request path before evaluating whitelist/blacklist rules to prevent bypass via URL encoding (%6e), double slashes (//), and dot segments (./, ../).

Normalization is opt-in: the `normalizeRequestPath` configuration flag
defaults to false, so existing configurations are not affected. It can
be enabled per policy instance.

***decodeEncodedSlash***
By default, `%2F/%2f` are preserved as literal characters during path normalization so that legitimate uses (e.g. identifiers containing a slash) are not altered.
When the new `decodeEncodedSlash` flag is enabled, they are decoded to `/` and then collapsed and resolved like any other slash, revealing dot-segment traversal attempts hidden behind encoded
slashes.
The flag only applies when `normalizeRequestPath` is enabled and defaults to false.

BREAKING CHANGE: requires APIM 4.7.0 minimum and JDK 21
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.0-update-project-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-resource-filtering/2.0.0-update-project-SNAPSHOT/gravitee-policy-resource-filtering-2.0.0-update-project-SNAPSHOT.zip)
  <!-- Version placeholder end -->
